### PR TITLE
Basic scripts and instructions for running the deployment standalone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Python virtualenv directories
+venv*
+
+# Kubernetes config files
+cluster.yml
+kube_config_cluster.yml
+
+# ssh keys for the underlying vms
+ssh_key*
+
+# Ansible files
+inventory
+playbooks/group_vars/all
+
+# Terraform files
+terraform.tfstate*
+terraform_plugins
+.terraform

--- a/README.md
+++ b/README.md
@@ -1,0 +1,123 @@
+# Terraform and ansible templates for rke-openstack (rega)
+
+Also see the (rke-openstack)[https://github.com/NBISweden/rke-openstack] repo
+for information.
+
+
+## Edit these files
+
+### Config terraform in `terraform.tfvars`
+
+```yml
+## Cluster configuration ##
+# Unique name for the resources
+cluster_prefix="my-test"
+# User for ssh connections. It varies among distributions. (CentOS might work with cloud-user or centos)
+ssh_user="<ssh-user>"
+# Network settings
+external_network_id=""
+floating_ip_pool=""
+# Image name (RKE runs on almost any Linux OS)
+image_name="<image-name>"
+# Node counts and flavours (Note that these flavours are only indicative)
+master_flavor_name="ssc.medium"
+master_count=1
+service_flavor_name="ssc.medium"
+service_count=2
+edge_flavor_name="ssc.medium"
+edge_count=1
+# Please check that the Kubernetes version is RKE 0.2.x compliant)
+kubernetes_version="v1.14.6-rancher1-1"
+
+# Security groups
+allowed_ingress_tcp={
+  # These are the ports you need to work with kubernetes and rancher from your
+  # machine.
+  #"<YOUR CIDR>" = [22, 6443, 80, 443, 10250]
+}
+allowed_ingress_udp={}
+secgroups = []
+```
+
+### Terraform state backend
+
+If you want the state to be stored into a S3 remote backend you can add the following configuration to the `backend.cfg` file:
+
+```
+access_key = "xyz"
+secret_key = "xyz"
+bucket = "bucketname"
+region = "us-east-1"
+endpoint = "https://s3.endpoint"
+key = "terraform.tfstate"
+skip_requesting_account_id = true
+skip_credentials_validation = true
+skip_get_ec2_platforms = true
+skip_metadata_api_check = true
+skip_region_validation = true
+```
+
+And for Swift:
+
+```
+container          = "cluster-state"
+archive_container  = "cluster-state-archive"
+```
+
+## Stand-alone deployment
+
+Create a private/public keypair with `ssh-keygen`.
+
+```bash
+ssh-keygen -f ssh_key
+```
+
+### Source the extra env vars
+
+```console
+source OPENSTACK_CREDENTIALS.sh
+source <(./scripts/01_source_extra_vars.sh)
+```
+
+### Init terraform
+
+```bash
+./scripts/02_init_download_terraform_plugins.sh
+terraform init -backend=backend.cfg
+```
+
+### Deploy
+
+```bash
+./scripts/03_apply_network.sh
+./scripts/04_apply_secgroups.sh
+./scripts/05_apply_infra.sh
+```
+
+Edit the `playbooks/roles/all` file to contain approximately:
+
+```yaml
+edge_host: {PREFIX}-edge-000
+edge_ip: '{{ hostvars.get(edge_host)["ansible_host"] }}'
+private_key: ssh_key
+ssh_user: ubuntu
+```
+
+Run ansible
+
+```bash
+./scripts/06_provision_docker.sh
+```
+
+Deploy rke cluster
+
+```bash
+./scripts/07_apply_rke.sh
+```
+
+To access the kubernetes environment
+
+```bash
+export KUBECONFIG="${PWD}/kube_config_cluster.yml"
+kubectl get nodes
+```

--- a/scripts/01_source_extra_vars.sh
+++ b/scripts/01_source_extra_vars.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+env | grep '^OS_' | perl -pE 's/^(OS_[^=]+)=(.*)/"export TF_VAR_" . lc($1) . "=\"$2\""/e'

--- a/scripts/02_init_download_terraform_plugins.sh
+++ b/scripts/02_init_download_terraform_plugins.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -e
+
+export ARCH=amd64
+# OS=darwin, OS=linux
+export OS=$(uname | tr '[:upper:]' '[:lower:]')
+# Terraform plugin versions
+export PLUGIN_OPENSTACK=1.21.1
+export PLUGIN_RKE=0.14.1
+export PLUGIN_KUBERNETES=1.8.1
+export PLUGIN_NULL=2.1.2
+export PLUGIN_LOCAL=1.3.0
+export PLUGIN_TEMPLATE=2.1.2
+export PLUGIN_RANDOM=2.2.0
+
+# Install Terraform plugins
+mkdir -p ./terraform_plugins
+curl "https://releases.hashicorp.com/terraform-provider-openstack/${PLUGIN_OPENSTACK}/terraform-provider-openstack_${PLUGIN_OPENSTACK}_${OS}_${ARCH}.zip" > \
+    "terraform-provider-openstack_${PLUGIN_OPENSTACK}_${OS}_${ARCH}.zip" && \
+    unzip "terraform-provider-openstack_${PLUGIN_OPENSTACK}_${OS}_${ARCH}.zip" -d ./terraform_plugins/ && \
+    rm "terraform-provider-openstack_${PLUGIN_OPENSTACK}_${OS}_${ARCH}.zip"
+
+curl "https://releases.hashicorp.com/terraform-provider-kubernetes/${PLUGIN_KUBERNETES}/terraform-provider-kubernetes_${PLUGIN_KUBERNETES}_${OS}_${ARCH}.zip" > \
+    "terraform-provider-kubernetes_${PLUGIN_KUBERNETES}_${OS}_${ARCH}.zip" && \
+    unzip "terraform-provider-kubernetes_${PLUGIN_KUBERNETES}_${OS}_${ARCH}.zip" -d ./terraform_plugins/ && \
+    rm "terraform-provider-kubernetes_${PLUGIN_KUBERNETES}_${OS}_${ARCH}.zip"
+
+curl "https://releases.hashicorp.com/terraform-provider-null/${PLUGIN_NULL}/terraform-provider-null_${PLUGIN_NULL}_${OS}_${ARCH}.zip" > \
+    "terraform-provider-null_${PLUGIN_NULL}_${OS}_${ARCH}.zip" && \
+    unzip "terraform-provider-null_${PLUGIN_NULL}_${OS}_${ARCH}.zip" -d ./terraform_plugins/ && \
+    rm "terraform-provider-null_${PLUGIN_NULL}_${OS}_${ARCH}.zip"
+
+curl "https://releases.hashicorp.com/terraform-provider-local/${PLUGIN_LOCAL}/terraform-provider-local_${PLUGIN_LOCAL}_${OS}_${ARCH}.zip" > \
+    "terraform-provider-local_${PLUGIN_LOCAL}_${OS}_${ARCH}.zip" && \
+    unzip "terraform-provider-local_${PLUGIN_LOCAL}_${OS}_${ARCH}.zip" -d ./terraform_plugins/ && \
+    rm "terraform-provider-local_${PLUGIN_LOCAL}_${OS}_${ARCH}.zip"
+
+curl -sL "https://github.com/yamamoto-febc/terraform-provider-rke/releases/download/${PLUGIN_RKE}/terraform-provider-rke_${PLUGIN_RKE}_${OS}-${ARCH}.zip" > \
+    "terraform-provider-rke_${PLUGIN_RKE}_${OS}_${ARCH}.zip" && \
+    unzip "terraform-provider-rke_${PLUGIN_RKE}_${OS}_${ARCH}.zip" -d ./terraform_plugins/ && \
+    rm "terraform-provider-rke_${PLUGIN_RKE}_${OS}_${ARCH}.zip"
+
+curl "https://releases.hashicorp.com/terraform-provider-template/${PLUGIN_TEMPLATE}/terraform-provider-template_${PLUGIN_TEMPLATE}_${OS}_${ARCH}.zip" > \
+    "terraform-provider-template_${PLUGIN_TEMPLATE}_${OS}_${ARCH}.zip" && \
+    unzip "terraform-provider-template_${PLUGIN_TEMPLATE}_${OS}_${ARCH}.zip" -d ./terraform_plugins/ && \
+    rm "terraform-provider-template_${PLUGIN_TEMPLATE}_${OS}_${ARCH}.zip"
+
+curl "https://releases.hashicorp.com/terraform-provider-random/${PLUGIN_RANDOM}/terraform-provider-random_${PLUGIN_RANDOM}_${OS}_${ARCH}.zip" > \
+    "terraform-provider-random_${PLUGIN_RANDOM}_${OS}_${ARCH}.zip" && \
+    unzip "terraform-provider-random_${PLUGIN_RANDOM}_${OS}_${ARCH}.zip" -d ./terraform_plugins/ && \
+    rm "terraform-provider-random_${PLUGIN_RANDOM}_${OS}_${ARCH}.zip"

--- a/scripts/03_apply_network.sh
+++ b/scripts/03_apply_network.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform apply -auto-approve -parallelism=10 -target=module.network

--- a/scripts/03_destroy_network.sh
+++ b/scripts/03_destroy_network.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform destroy -auto-approve -parallelism=10 -target=module.network

--- a/scripts/03_plan_network.sh
+++ b/scripts/03_plan_network.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform plan -parallelism=10 -target=module.network 

--- a/scripts/04_apply_secgroups.sh
+++ b/scripts/04_apply_secgroups.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform apply -auto-approve -parallelism=1  -target=module.secgroup

--- a/scripts/04_destroy_secgroups.sh
+++ b/scripts/04_destroy_secgroups.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform destroy -auto-approve -parallelism=1  -target=module.secgroup

--- a/scripts/04_plan_secgroups.sh
+++ b/scripts/04_plan_secgroups.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform plan -parallelism=1  -target=module.secgroup

--- a/scripts/05_apply_infra.sh
+++ b/scripts/05_apply_infra.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform apply -auto-approve -parallelism=10 -target=module.master -target=module.service -target=module.edge -target=module.inventory -target=module.keypair

--- a/scripts/05_destroy_infra.sh
+++ b/scripts/05_destroy_infra.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform destroy -auto-approve -parallelism=10 -target=module.master -target=module.service -target=module.edge -target=module.inventory -target=module.keypair

--- a/scripts/05_plan_infra.sh
+++ b/scripts/05_plan_infra.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform plan -parallelism=10 -target=module.master -target=module.service -target=module.edge -target=module.inventory -target=module.keypair

--- a/scripts/06_apply_docker.sh
+++ b/scripts/06_apply_docker.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+ansible-playbook playbooks/setup.yml

--- a/scripts/07_apply_rke.sh
+++ b/scripts/07_apply_rke.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform apply -auto-approve -parallelism=10 -target=module.rke

--- a/scripts/07_destroy_rke.sh
+++ b/scripts/07_destroy_rke.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform destroy -auto-approve -parallelism=10 -target=module.rke

--- a/scripts/07_plan_rke.sh
+++ b/scripts/07_plan_rke.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+terraform plan -target=module.rke


### PR DESCRIPTION
This should make it easy to run the deployment without relying on the REGA tool.

Next step is to have rega automatically detect the different steps in the `./scripts/` directory.