### PR TITLE
Support for previously allocated IPs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,7 @@ module "master" {
   ssh_key            = var.ssh_key
   os_ssh_keypair     = module.keypair.keypair_name
   assign_floating_ip = var.master_assign_floating_ip
+  dns_mapped_ips     = var.dns_mapped_ips
   role               = var.master_node_roles
   node_label         = var.master_node_label
 }
@@ -54,6 +55,7 @@ module "service" {
   ssh_key            = var.ssh_key
   os_ssh_keypair     = module.keypair.keypair_name
   assign_floating_ip = var.service_assign_floating_ip
+  dns_mapped_ips     = var.dns_mapped_ips
   role               = ["worker"]
   node_label         = var.service_node_label
 }
@@ -73,6 +75,7 @@ module "edge" {
   ssh_key            = var.ssh_key
   os_ssh_keypair     = module.keypair.keypair_name
   assign_floating_ip = var.edge_assign_floating_ip
+  dns_mapped_ips     = var.dns_mapped_ips
   role               = ["worker"]
   node_label         = var.edge_node_label
 }

--- a/modules/node/variables.tf
+++ b/modules/node/variables.tf
@@ -48,6 +48,10 @@ variable "floating_ip_pool" {
   default     = ""
 }
 
+variable "dns_mapped_ips" {
+  description = "Existing IP addresses to associate to instances"
+}
+
 variable "role" {
   description = "Role for this node"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -121,6 +121,11 @@ variable "edge_assign_floating_ip" {
   default     = true
 }
 
+variable "dns_mapped_ips" {
+  type = "list"
+  default = [""]
+}
+
 # Type for this one and next is supposed to be map(list(number)), but then the
 # pyhcl library can't parse the tf file, so for now it will stay like this, the
 # real type constraint can be found in modules/secgroup/variables.tf


### PR DESCRIPTION
Now we can manually define previously allocated IPs to associate to instances. This is achieved by terraform workspaces.