### PR TITLE
Add init call to plan and apply scripts

### DIFF
--- a/scripts/03_apply_network.sh
+++ b/scripts/03_apply_network.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+terraform init -input=false -backend-config=backend.cfg -plugin-dir=terraform_plugins
 terraform apply -auto-approve -parallelism=10 -target=module.network

--- a/scripts/03_plan_network.sh
+++ b/scripts/03_plan_network.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+terraform init -input=false -backend-config=backend.cfg -plugin-dir=terraform_plugins
 terraform plan -parallelism=10 -target=module.network 

--- a/scripts/04_apply_secgroups.sh
+++ b/scripts/04_apply_secgroups.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-terraform apply -auto-approve -parallelism=1  -target=module.secgroup
+terraform init -input=false -backend-config=backend.cfg -plugin-dir=terraform_plugins
+terraform apply -auto-approve -parallelism=1 -target=module.secgroup

--- a/scripts/04_plan_secgroups.sh
+++ b/scripts/04_plan_secgroups.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-terraform plan -parallelism=1  -target=module.secgroup
+terraform init -input=false -backend-config=backend.cfg -plugin-dir=terraform_plugins
+terraform plan -parallelism=1 -target=module.secgroup

--- a/scripts/05_apply_infra.sh
+++ b/scripts/05_apply_infra.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+terraform init -input=false -backend-config=backend.cfg -plugin-dir=terraform_plugins
 terraform apply -auto-approve -parallelism=10 -target=module.master -target=module.service -target=module.edge -target=module.inventory -target=module.keypair

--- a/scripts/05_plan_infra.sh
+++ b/scripts/05_plan_infra.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+terraform init -input=false -backend-config=backend.cfg -plugin-dir=terraform_plugins
 terraform plan -parallelism=10 -target=module.master -target=module.service -target=module.edge -target=module.inventory -target=module.keypair

--- a/scripts/07_apply_rke.sh
+++ b/scripts/07_apply_rke.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+terraform init -input=false -backend-config=backend.cfg -plugin-dir=terraform_plugins
 terraform apply -auto-approve -parallelism=10 -target=module.rke

--- a/scripts/07_plan_rke.sh
+++ b/scripts/07_plan_rke.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
+terraform init -input=false -backend-config=backend.cfg -plugin-dir=terraform_plugins
 terraform plan -target=module.rke


### PR DESCRIPTION
Terraform init should be run prior to any plan or apply call, since state migrations or credential changes might happen.